### PR TITLE
fix: added clipboard write permission

### DIFF
--- a/src/helpers/iframe.ts
+++ b/src/helpers/iframe.ts
@@ -33,6 +33,7 @@ export function createEmbedIframe(
   iframeUrl.hash = pathHash;
 
   iframe.src = iframeUrl.toString();
+  iframe.allow = `clipboard-write ${iframeUrl.origin}`;
 
   return iframe;
 }


### PR DESCRIPTION
added `clipboard-write` permission to iframe context. Seems like Safari and Firefox had no issues with copying, only Chrome.

